### PR TITLE
Add support to compute tSNR maps for multi-echo data

### DIFF
--- a/derivatives/tsnr/avg_tsnr_maps.py
+++ b/derivatives/tsnr/avg_tsnr_maps.py
@@ -69,10 +69,12 @@ def main(ds_name, ds_path, avg_mni, avg_t1w, echo, me):
                     sub_list = [f.get_image() for f in layout.get(**elem_entities) if 'stat-tsnr' in f.filename]
                     # Compute mean only if `sub_list` not empty
                     if len(sub_list)>0:
-                        sub_mean = mean_img(sub_list, copy_header=True)
+                        logger.info(f'Computing averaged tSNR map for {elem_entities["subject"]}')
+                        sub_mean = mean_img(sub_list)
                         # Save averaged map
                         sub_mean.to_filename(out_file)
                         logger.info(f'Average computed for files with entities: \n{elem_entities}')
+                        logger.info(f'Average maps saved : \n{out_file}')
                     else:
                         logger.info(f'Cannot compute average tsnr maps for files with entities: \n{elem_entities}')
 

--- a/derivatives/tsnr/avg_tsnr_maps.py
+++ b/derivatives/tsnr/avg_tsnr_maps.py
@@ -1,6 +1,7 @@
-import os, glob
+import logging
 from pathlib import Path
 
+import bids
 import click
 from nilearn.image import mean_img
 
@@ -8,27 +9,76 @@ from nilearn.image import mean_img
 @click.command()
 @click.argument('ds_name', type=str)
 @click.argument('ds_path', type=click.Path())
-@click.option('--avg_MNI', is_flag=True)
-@click.option('--avg_T1w', is_flag=True)
-def main(ds_name, ds_path, avg_MNI, avg_T1w):
+@click.option('--avg_mni', is_flag=True)
+@click.option('--avg_t1w', is_flag=True)
+@click.option('--echo', type=str, default=None, help='Specify the echo value on which the tSNR maps were computed')
+@click.option('--me', is_flag=True, help='Flag to specify if working with tedana outputs. If specified, will compute tSNR maps for optcom and denoised images')
+def main(ds_name, ds_path, avg_mni, avg_t1w, echo, me):
+    logger = logging.getLogger(__name__)
+    logger.info(f'averaging tsnr maps from {Path(ds_path).name} data for the {ds_name} dataset')
+    logger.info(f"loading tSNR maps: {ds_name}")
 
-    for sub_path in glob.glob(f"{ds_path}/sub*"):
-        sub_num = os.path.basename(sub_path)
+    ds_path = str(Path(ds_path))
+    layout = bids.BIDSLayout(ds_path, is_derivative=True, validate=False)
+
+    for sub in layout.get_subject():
         
-        if avg_MNI:
-            sub_list_MNI = sorted(glob.glob(f"{ds_path}/{sub_num}/ses*/func/*MNI152NLin2009cAsym*stat-tsnr*nii.gz"))
-            sub_mean_MNI = mean_img(sub_list_MNI, copy_header=True)
-            sub_mean_MNI.to_filename(
-                f"{ds_path}/{sub_num}/{sub_num}_task-{ds_name}_space-MNI152NLin2009cAsym_stat-avgtsnr_statmap.nii.gz"
-            )
-        if avg_T1w:
-            sub_list_t1w = sorted(glob.glob(f"{ds_path}/{sub_num}/ses*/func/*T1w*stat-tsnr*nii.gz"))
-            sub_mean_t1w = mean_img(sub_list_t1w, copy_header=True)
-            sub_mean_t1w.to_filename(
-                f"{ds_path}/{sub_num}/{sub_num}_task-{ds_name}_space-T1w_stat-avgtsnr_statmap.nii.gz"
-            )
+        list_entities = []
+        spaces = []
+
+        entities = {
+            'task': ds_name,
+            'subject': sub,
+            'suffix': 'statmap',
+            'extension': '.nii.gz'
+        }
+        pattern = "sub-{subject}/sub-{subject}_task-{task}_space-{space}[_echo-{echo}]_stat-avgtsnr[_desc-{desc}]_statmap.nii.gz"
+
+        if echo is not None:
+            tmp_entities = entities.copy()
+            tmp_entities.update({'echo': echo, 'desc': 'preproc'})
+            list_entities.append(tmp_entities)
+        if me:
+            # Add optcom descriptor
+            tmp_entities = entities.copy()
+            tmp_entities.update({'desc': 'optcom'})
+            list_entities.append(tmp_entities)
+            # Add denoised descriptor
+            tmp_entities = entities.copy()
+            tmp_entities.update({'desc': 'denoised'})
+            list_entities.append(tmp_entities)
+        if not me and echo is None:
+            list_entities.append(entities)
+        
+        if avg_mni:
+            spaces.append('MNI152NLin2009cAsym')
+        if avg_t1w:
+            spaces.append('T1w')
+
+        for elem_entities in list_entities:
+            for space in spaces:
+                elem_entities.update({'space': space})
+                # Create output filename
+                tmp_entities = elem_entities.copy()
+                tmp_entities.update({'stat': 'avgtsnr'})
+                out_file = layout.build_path(tmp_entities, pattern, validate=False)
+
+                Path(out_file).parent.mkdir(parents=True, exist_ok=True)
+                if not Path(out_file).exists():
+                    # Retrieve files based on entities specified in `elem_entities`
+                    sub_list = [f.get_image() for f in layout.get(**elem_entities) if 'stat-tsnr' in f.filename]
+                    # Compute mean only if `sub_list` not empty
+                    if len(sub_list)>0:
+                        sub_mean = mean_img(sub_list, copy_header=True)
+                        # Save averaged map
+                        sub_mean.to_filename(out_file)
+                        logger.info(f'Average computed for files with entities: \n{elem_entities}')
+                    else:
+                        logger.info(f'Cannot compute average tsnr maps for files with entities: \n{elem_entities}')
 
 
 if __name__ == '__main__':
+    log_fmt = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    logging.basicConfig(level=logging.INFO, format=log_fmt)
 
     main()

--- a/derivatives/tsnr/avg_tsnr_maps.py
+++ b/derivatives/tsnr/avg_tsnr_maps.py
@@ -12,8 +12,8 @@ from nilearn.image import mean_img
 @click.option('--avg_mni', is_flag=True)
 @click.option('--avg_t1w', is_flag=True)
 @click.option('--echo', type=str, default=None, help='Specify the echo value on which the tSNR maps were computed')
-@click.option('--me', is_flag=True, help='Flag to specify if working with tedana outputs. If specified, will compute tSNR maps for optcom and denoised images')
-def main(ds_name, ds_path, avg_mni, avg_t1w, echo, me):
+@click.option('--tedana', is_flag=True, help='Flag to specify if working with tedana outputs. If specified, will compute tSNR maps for optcom and denoised images')
+def main(ds_name, ds_path, avg_mni, avg_t1w, echo, tedana):
     logger = logging.getLogger(__name__)
     logger.info(f'averaging tsnr maps from {Path(ds_path).name} data for the {ds_name} dataset')
     logger.info(f"loading tSNR maps: {ds_name}")
@@ -38,7 +38,7 @@ def main(ds_name, ds_path, avg_mni, avg_t1w, echo, me):
             tmp_entities = entities.copy()
             tmp_entities.update({'echo': echo, 'desc': 'preproc'})
             list_entities.append(tmp_entities)
-        if me:
+        if tedana:
             # Add optcom descriptor
             tmp_entities = entities.copy()
             tmp_entities.update({'desc': 'optcom'})
@@ -47,7 +47,7 @@ def main(ds_name, ds_path, avg_mni, avg_t1w, echo, me):
             tmp_entities = entities.copy()
             tmp_entities.update({'desc': 'denoised'})
             list_entities.append(tmp_entities)
-        if not me and echo is None:
+        if not tedana and echo is None:
             list_entities.append(entities)
         
         if avg_mni:

--- a/derivatives/tsnr/avg_tsnr_maps.py
+++ b/derivatives/tsnr/avg_tsnr_maps.py
@@ -8,22 +8,25 @@ from nilearn.image import mean_img
 @click.command()
 @click.argument('ds_name', type=str)
 @click.argument('ds_path', type=click.Path())
-def main(ds_name, ds_path):
+@click.option('--avg_MNI', is_flag=True)
+@click.option('--avg_T1w', is_flag=True)
+def main(ds_name, ds_path, avg_MNI, avg_T1w):
 
     for sub_path in glob.glob(f"{ds_path}/sub*"):
         sub_num = os.path.basename(sub_path)
-
-        sub_list_MNI = sorted(glob.glob(f"{ds_path}/{sub_num}/ses*/func/*MNI152NLin2009cAsym*stat-tsnr*nii.gz"))
-        sub_mean_MNI = mean_img(sub_list_MNI, copy_header=True)
-        sub_mean_MNI.to_filename(
-            f"{ds_path}/{sub_num}/{sub_num}_task-{ds_name}_space-MNI152NLin2009cAsym_stat-avgtsnr_statmap.nii.gz"
-        )
-
-        sub_list_t1w = sorted(glob.glob(f"{ds_path}/{sub_num}/ses*/func/*T1w*stat-tsnr*nii.gz"))
-        sub_mean_t1w = mean_img(sub_list_t1w, copy_header=True)
-        sub_mean_t1w.to_filename(
-            f"{ds_path}/{sub_num}/{sub_num}_task-{ds_name}_space-T1w_stat-avgtsnr_statmap.nii.gz"
-        )
+        
+        if avg_MNI:
+            sub_list_MNI = sorted(glob.glob(f"{ds_path}/{sub_num}/ses*/func/*MNI152NLin2009cAsym*stat-tsnr*nii.gz"))
+            sub_mean_MNI = mean_img(sub_list_MNI, copy_header=True)
+            sub_mean_MNI.to_filename(
+                f"{ds_path}/{sub_num}/{sub_num}_task-{ds_name}_space-MNI152NLin2009cAsym_stat-avgtsnr_statmap.nii.gz"
+            )
+        if avg_T1w:
+            sub_list_t1w = sorted(glob.glob(f"{ds_path}/{sub_num}/ses*/func/*T1w*stat-tsnr*nii.gz"))
+            sub_mean_t1w = mean_img(sub_list_t1w, copy_header=True)
+            sub_mean_t1w.to_filename(
+                f"{ds_path}/{sub_num}/{sub_num}_task-{ds_name}_space-T1w_stat-avgtsnr_statmap.nii.gz"
+            )
 
 
 if __name__ == '__main__':

--- a/derivatives/tsnr/make_tsnr_maps.py
+++ b/derivatives/tsnr/make_tsnr_maps.py
@@ -15,7 +15,7 @@ from nipype.algorithms.confounds import TSNR
 @click.option('--echo', type=str, default=None, help='Specify the echo value to compute tSNR maps from fMRIPrep outputs')
 @click.option('--me', is_flag=True, help='Flag to specify if working with tedana outputs. If specified, will compute tSNR maps for optcom and denoised images')
 def main(ds_name, ds_path, output_filepath, echo, me):
-    tsnr_maps(ds_name, ds_path, output_filepath, echo, me)
+    tsnr_maps(ds_name, str(Path(ds_path)), str(Path(output_filepath)), echo, me)
 
 def tsnr_maps(ds_name, ds_path, output_filepath, echo=None, me=False):
     logger = logging.getLogger(__name__)
@@ -32,7 +32,21 @@ def tsnr_maps(ds_name, ds_path, output_filepath, echo=None, me=False):
         bolds = layout.get(suffix='bold', extension='.nii.gz', desc='preproc', echo=echo)
 
     for bold in bolds:
-        tsnr_path = bold.path.replace(ds_path,output_filepath).replace('_part-mag','').replace(f'desc-{bold.get_entities()["desc"]}',f'stat-tsnr_desc-{bold.get_entities()["desc"]}').replace('bold','statmap')
+        entities = bold.get_entities()
+        entities_tsnr = {
+            'datatype': entities['datatype'],
+            'subject': entities['subject'],
+            'session': entities['session'],
+            'task': entities['task'],
+            'run': entities['run'],
+            'echo': echo,
+            'stat': 'tsnr',
+            'desc': entities['desc'],
+            'suffix': 'statmap',
+            'extension': '.nii.gz'
+        }
+        pattern="sub-{subject}/ses-{session}/{datatype}/sub-{subject}_ses-{session}_task-{task}_run-{run}[_echo-{echo}]_stat-tsnr_desc-{desc}_statmap.nii.gz"
+        tsnr_path = layout.build_path(entities_tsnr, pattern, validate=False).replace(ds_path, output_filepath)
 
         Path(tsnr_path).parent.mkdir(parents=True, exist_ok=True)
         if not Path(tsnr_path).exists():

--- a/derivatives/tsnr/make_tsnr_maps.py
+++ b/derivatives/tsnr/make_tsnr_maps.py
@@ -44,6 +44,7 @@ def tsnr_maps(ds_name, ds_path, output_filepath, echo=None, me=False):
         Path(tsnr_path).parent.mkdir(parents=True, exist_ok=True)
         if not Path(tsnr_path).exists():
             try:
+                logger.info(f'Computing tSNR maps for: {bold.filename}')
                 tsnr_if = TSNR(
                     in_file=bold.path,
                     tsnr_file=tsnr_path,

--- a/derivatives/tsnr/make_tsnr_maps.py
+++ b/derivatives/tsnr/make_tsnr_maps.py
@@ -33,20 +33,14 @@ def tsnr_maps(ds_name, ds_path, output_filepath, echo=None, me=False):
 
     for bold in bolds:
         entities = bold.get_entities()
-        entities_tsnr = {
-            'datatype': entities['datatype'],
-            'subject': entities['subject'],
-            'session': entities['session'],
-            'task': entities['task'],
-            'run': entities['run'],
+        entities.update({
             'echo': echo,
             'stat': 'tsnr',
-            'desc': entities['desc'],
-            'suffix': 'statmap',
-            'extension': '.nii.gz'
-        }
-        pattern="sub-{subject}/ses-{session}/{datatype}/sub-{subject}_ses-{session}_task-{task}_run-{run}[_echo-{echo}]_stat-tsnr_desc-{desc}_statmap.nii.gz"
-        tsnr_path = layout.build_path(entities_tsnr, pattern, validate=False).replace(ds_path, output_filepath)
+            'suffix': 'statmap'
+        })
+
+        pattern="sub-{subject}/ses-{session}/{datatype}/sub-{subject}_ses-{session}_task-{task}_run-{run}[_echo-{echo}]_stat-{stat}_desc-{desc}_{suffix}.nii.gz"
+        tsnr_path = layout.build_path(entities, pattern, validate=False).replace(ds_path, output_filepath)
 
         Path(tsnr_path).parent.mkdir(parents=True, exist_ok=True)
         if not Path(tsnr_path).exists():
@@ -60,7 +54,7 @@ def tsnr_maps(ds_name, ds_path, output_filepath, echo=None, me=False):
                 tsnr_if.run()
                 del tsnr_if
             except:
-                logger.info(f"could not process {os.path.basename(bold.path)}")
+                logger.info(f"could not process {bold.filename}")
 
     
 if __name__ == '__main__':

--- a/derivatives/tsnr/make_tsnr_maps.py
+++ b/derivatives/tsnr/make_tsnr_maps.py
@@ -12,19 +12,28 @@ from nipype.algorithms.confounds import TSNR
 @click.argument('ds_name', type=str)
 @click.argument('ds_path', type=click.Path())
 @click.argument('output_filepath', type=click.Path())
-def main(ds_name, ds_path, output_filepath):
-    tsnr_maps(ds_name, ds_path, output_filepath)
+@click.option('--echo', type=str, default=None, help='Specify the echo value to compute tSNR maps from fMRIPrep outputs')
+@click.option('--me', is_flag=True, help='Flag to specify if working with tedana outputs. If specified, will compute tSNR maps for optcom and denoised images')
+def main(ds_name, ds_path, output_filepath, echo, me):
+    tsnr_maps(ds_name, ds_path, output_filepath, echo, me)
 
-def tsnr_maps(ds_name, ds_path, output_filepath):
+def tsnr_maps(ds_name, ds_path, output_filepath, echo=None, me=False):
     logger = logging.getLogger(__name__)
     logger.info(f'generating tsnr maps from fmriprep data for the {ds_name} dataset')
     logger.info(f"loading BIDS: {ds_name}")
 
     layout = bids.BIDSLayout(ds_path, validate=False)
-    bolds = layout.get(suffix='bold', extension='.nii.gz', desc='preproc')
+    if me:
+        # Get optimally combined and denoised images
+        bolds_optcom = layout.get(suffix='bold', extension='.nii.gz', desc='optcom')
+        bolds_denoised = layout.get(suffix='bold', extension='.nii.gz', desc='denoised')
+        bolds = [*bolds_optcom, *bolds_denoised]
+    else:
+        bolds = layout.get(suffix='bold', extension='.nii.gz', desc='preproc', echo=echo)
 
     for bold in bolds:
-        tsnr_path = bold.path.replace(ds_path,output_filepath).replace('_part-mag','').replace('desc-preproc','stat-tsnr').replace('bold','statmap')
+        tsnr_path = bold.path.replace(ds_path,output_filepath).replace('_part-mag','').replace(f'desc-{bold.get_entities()["desc"]}',f'stat-tsnr_desc-{bold.get_entities()["desc"]}').replace('bold','statmap')
+
         Path(tsnr_path).parent.mkdir(parents=True, exist_ok=True)
         if not Path(tsnr_path).exists():
             try:

--- a/derivatives/tsnr/make_tsnr_maps.py
+++ b/derivatives/tsnr/make_tsnr_maps.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
 import logging
 from pathlib import Path
 

--- a/derivatives/tsnr/make_tsnr_maps.py
+++ b/derivatives/tsnr/make_tsnr_maps.py
@@ -12,17 +12,17 @@ from nipype.algorithms.confounds import TSNR
 @click.argument('ds_path', type=click.Path())
 @click.argument('output_filepath', type=click.Path())
 @click.option('--echo', type=str, default=None, help='Specify the echo value to compute tSNR maps from fMRIPrep outputs')
-@click.option('--me', is_flag=True, help='Flag to specify if working with tedana outputs. If specified, will compute tSNR maps for optcom and denoised images')
-def main(ds_name, ds_path, output_filepath, echo, me):
-    tsnr_maps(ds_name, str(Path(ds_path)), str(Path(output_filepath)), echo, me)
+@click.option('--tedana', is_flag=True, help='Flag to specify if working with tedana outputs. If specified, will compute tSNR maps for optcom and denoised images')
+def main(ds_name, ds_path, output_filepath, echo, tedana):
+    tsnr_maps(ds_name, str(Path(ds_path)), str(Path(output_filepath)), echo, tedana)
 
-def tsnr_maps(ds_name, ds_path, output_filepath, echo=None, me=False):
+def tsnr_maps(ds_name, ds_path, output_filepath, echo=None, tedana=False):
     logger = logging.getLogger(__name__)
     logger.info(f'generating tsnr maps from {Path(ds_path).name.split('.')[-1]} data for the {ds_name} dataset')
     logger.info(f"loading BIDS: {ds_name}")
 
     layout = bids.BIDSLayout(ds_path, validate=False)
-    if me:
+    if tedana:
         # Get optimally combined and denoised images
         bolds_optcom = layout.get(suffix='bold', extension='.nii.gz', desc='optcom')
         bolds_denoised = layout.get(suffix='bold', extension='.nii.gz', desc='denoised')

--- a/derivatives/tsnr/make_tsnr_maps.py
+++ b/derivatives/tsnr/make_tsnr_maps.py
@@ -19,7 +19,7 @@ def main(ds_name, ds_path, output_filepath, echo, me):
 
 def tsnr_maps(ds_name, ds_path, output_filepath, echo=None, me=False):
     logger = logging.getLogger(__name__)
-    logger.info(f'generating tsnr maps from fmriprep data for the {ds_name} dataset')
+    logger.info(f'generating tsnr maps from {Path(ds_path).name.split('.')[-1]} data for the {ds_name} dataset')
     logger.info(f"loading BIDS: {ds_name}")
 
     layout = bids.BIDSLayout(ds_path, validate=False)

--- a/derivatives/tsnr/resample_tsnr_maps.py
+++ b/derivatives/tsnr/resample_tsnr_maps.py
@@ -1,4 +1,3 @@
-import os
 import logging
 from pathlib import Path
 

--- a/derivatives/tsnr/resample_tsnr_maps.py
+++ b/derivatives/tsnr/resample_tsnr_maps.py
@@ -1,0 +1,89 @@
+import os
+import logging
+from pathlib import Path
+
+import bids
+import click
+
+from ants import image_read, image_write
+from ants.registration import apply_transforms
+
+@click.command()
+@click.argument('ds_name', type=str)
+@click.argument('tsnr_path', type=click.Path())
+@click.argument('fmriprep_path', type=click.Path())
+def main(ds_name, tsnr_path, fmriprep_path):
+    resample_to_T1w(ds_name, tsnr_path, fmriprep_path)
+
+def resample_to_T1w(ds_name, tsnr_path, fmriprep_path):
+    logger = logging.getLogger(__name__)
+    logger.info(f'generating tsnr maps from {Path(tsnr_path).name.split('.')[-1]} data for the {ds_name} dataset')
+    logger.info(f"loading tSNR data: {tsnr_path}")
+    layout_tsnr = bids.BIDSLayout(tsnr_path, validate=False, is_derivative=True)
+
+    logger.info(f"loading fMRIPrep data: {fmriprep_path}")
+    layout_fmriprep = bids.BIDSLayout(fmriprep_path, validate=False, is_derivative=True)
+    
+    tsnr_maps = [f for f in layout_tsnr.get(suffix='statmap') if 'stat-tsnr' in f.filename and 'space-T1w' not in f.filename]
+
+    for tsnr_map in tsnr_maps:
+        entities = tsnr_map.get_entities()
+        out_file = tsnr_map.path.replace(f'run-{entities["run"]}', f'run-{entities["run"]}_space-T1w')
+        
+        Path(out_file).parent.mkdir(parents=True, exist_ok=True)
+        if not Path(out_file).exists():
+            # Get reference images from fMRIPrep directory
+            t1w = layout_fmriprep.get(
+                subject=entities['subject'],
+                session=entities['session'],
+                run=entities['run'],
+                space='T1w',
+                suffix='boldref',
+                extension='nii.gz'
+            )
+            # Validate input
+            if len(t1w) == 0:
+                raise IOError(f"No T1w file associated with {tsnr_map.filename}")
+            elif len(t1w) > 1:
+                raise IOError(f"More than one T1w file associated with {tsnr_map.filename}")
+            else:
+                t1w = t1w[0]
+            
+            # Get transform from fMRIPrep directory
+            transform = layout_fmriprep.get(
+                subject=entities['subject'],
+                session=entities['session'],
+                run=entities['run'],
+                desc='coreg',
+                suffix='xfm',
+                extension='txt'
+            )
+            # Validate input
+            if len(transform) == 0:
+                raise IOError(f"No transform file associated with {tsnr_map.filename}")
+            elif len(transform) > 1:
+                raise IOError(f"More than one transform file associated with {tsnr_map.filename}")
+            else:
+                transform = transform[0]
+            
+            try:
+                # Resample tsnr map using ants
+                tsnr_T1w = apply_transforms(
+                    fixed=image_read(t1w.path),
+                    moving=image_read(tsnr_map.path),
+                    transformlist=[transform.path],
+                    interpolation='linear'
+                )
+                # Save resampled map
+                image_write(
+                    tsnr_T1w, 
+                    out_file
+                )
+            except:
+                logger.info(f"Could not resample {os.path.basename(tsnr_map.path)}")
+
+if __name__ == '__main__':
+    log_fmt = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    logging.basicConfig(level=logging.INFO, format=log_fmt)
+
+    main()

--- a/derivatives/tsnr/resample_tsnr_maps.py
+++ b/derivatives/tsnr/resample_tsnr_maps.py
@@ -48,9 +48,9 @@ def resample_to_T1w(ds_name, tsnr_path, fmriprep_path):
             )
             # Validate input
             if len(t1w) == 0:
-                raise IOError(f"No T1w boldref file associated with {tsnr_map.filename}")
+                raise FileNotFoundError(f"No T1w boldref file associated with {tsnr_map.filename}")
             elif len(t1w) > 1:
-                raise IOError(f"More than one T1w boldref file associated with {tsnr_map.filename}")
+                raise ValueError(f"More than one T1w boldref file associated with {tsnr_map.filename}")
             else:
                 t1w = t1w[0]
             
@@ -65,9 +65,9 @@ def resample_to_T1w(ds_name, tsnr_path, fmriprep_path):
             )
             # Validate input
             if len(transform) == 0:
-                raise IOError(f"No transform file associated with {tsnr_map.filename}")
+                raise FileNotFoundError(f"No transform file associated with {tsnr_map.filename}")
             elif len(transform) > 1:
-                raise IOError(f"More than one transform file associated with {tsnr_map.filename}")
+                raise ValueError(f"More than one transform file associated with {tsnr_map.filename}")
             else:
                 transform = transform[0]
             

--- a/derivatives/tsnr/resample_tsnr_maps.py
+++ b/derivatives/tsnr/resample_tsnr_maps.py
@@ -11,8 +11,15 @@ from ants.registration import apply_transforms
 @click.argument('ds_name', type=str)
 @click.argument('tsnr_path', type=click.Path())
 @click.argument('fmriprep_path', type=click.Path())
-def main(ds_name, tsnr_path, fmriprep_path):
-    resample_to_T1w(ds_name, tsnr_path, fmriprep_path)
+@click.option('--smriprep_path', type=click.Path(), default=None)
+@click.option('--to_t1w', is_flag=True)
+@click.option('--to_mni', is_flag=True)
+def main(ds_name, tsnr_path, fmriprep_path, smriprep_path=None, to_t1w=True, to_mni=False):
+    if to_t1w:
+        resample_to_T1w(ds_name, tsnr_path, fmriprep_path)
+    if to_mni:
+        resample_to_MNI152(ds_name, tsnr_path, fmriprep_path, smriprep_path)
+
 
 def resample_to_T1w(ds_name, tsnr_path, fmriprep_path):
     logger = logging.getLogger(__name__)
@@ -72,6 +79,7 @@ def resample_to_T1w(ds_name, tsnr_path, fmriprep_path):
                 transform = transform[0]
             
             try:
+                logger.info(f'Applying transform on {tsnr_map.filename}')
                 # Resample tsnr map using ants
                 tsnr_T1w = apply_transforms(
                     fixed=image_read(t1w.path),
@@ -86,6 +94,93 @@ def resample_to_T1w(ds_name, tsnr_path, fmriprep_path):
                 )
             except:
                 logger.info(f"Could not resample {tsnr_map.filename}")
+
+def resample_to_MNI152(ds_name, tsnr_path, fmriprep_path, smriprep_path):
+    logger = logging.getLogger(__name__)
+    logger.info(f'generating tsnr maps from {Path(tsnr_path).name.split('.')[-1]} data for the {ds_name} dataset')
+    logger.info(f"loading tSNR data: {tsnr_path}")
+    layout_tsnr = bids.BIDSLayout(tsnr_path, validate=False, is_derivative=True)
+    subjects = layout_tsnr.get_subjects()
+
+    logger.info(f"loading fMRIPrep data: {fmriprep_path}")
+    layout_fmriprep = bids.BIDSLayout(fmriprep_path, validate=False, is_derivative=True)
+
+    logger.info(f"loading sMRIPrep data: {smriprep_path}")
+    layout_smriprep = bids.BIDSLayout(smriprep_path, validate=False, is_derivative=True)
+
+    for subject in subjects:
+        # Retrieve T1w to MNI transformation
+        to_mni = [f for f in layout_smriprep.get(subject=subject, suffix='xfm', extension='h5') if 'to-MNI152NLin2009cAsym' in f.filename]
+        # Validate input
+        if len(to_mni) == 0:
+            raise IOError(f"No transformation from T1w to MNI file associated with {tsnr_map.filename}")
+        elif len(to_mni) > 1:
+            raise IOError(f"More than one transformation from T1w to MNI file associated with {tsnr_map.filename}")
+        else:
+            to_mni = to_mni[0]
+
+        tsnr_maps = [f for f in layout_tsnr.get(subject=subject, suffix='statmap', extension='.nii.gz') if 'stat-tsnr' in f.filename and 'space' not in f.filename]
+
+        for tsnr_map in tsnr_maps:
+            entities = tsnr_map.get_entities()
+            entities.update({
+                'space': 'MNI152NLin2009cAsym',
+                'stat': 'tsnr',
+            })
+
+            pattern = pattern="sub-{subject}/ses-{session}/{datatype}/sub-{subject}_ses-{session}_task-{task}_run-{run}_space-{space}[_echo-{echo}]_stat-{stat}_desc-{desc}_{suffix}.nii.gz"
+            out_file = layout_tsnr.build_path(entities, pattern, validate=False)
+
+            Path(out_file).parent.mkdir(parents=True, exist_ok=True)
+            if not Path(out_file).exists():
+                # Get reference images from fMRIPrep directory
+                ref = layout_fmriprep.get(
+                    subject=entities['subject'],
+                    session=entities['session'],
+                    run=entities['run'],
+                    space='MNI152NLin2009cAsym',
+                    suffix='boldref',
+                    extension='nii.gz'
+                )
+                # Validate input
+                if len(ref) == 0:
+                    raise IOError(f"No ref boldref file associated with {tsnr_map.filename}")
+                elif len(ref) > 1:
+                    raise IOError(f"More than one ref boldref file associated with {tsnr_map.filename}")
+                else:
+                    ref = ref[0]
+                
+                # Get transform from fMRIPrep directory
+                transform = layout_fmriprep.get(
+                    subject=entities['subject'],
+                    session=entities['session'],
+                    run=entities['run'],
+                    desc='coreg',
+                    suffix='xfm',
+                    extension='txt'
+                )
+                # Validate input
+                if len(transform) == 0:
+                    raise IOError(f"No transform file associated with {tsnr_map.filename}")
+                elif len(transform) > 1:
+                    raise IOError(f"More than one transform file associated with {tsnr_map.filename}")
+                else:
+                    transform = transform[0]
+
+                logger.info(f'Applying transform on {tsnr_map.filename}')
+                # Resample tsnr map using ants
+                tsnr_MNI = apply_transforms(
+                    fixed=image_read(ref.path),
+                    moving=image_read(tsnr_map.path),
+                    transformlist= [to_mni.path, transform.path],
+                    interpolation='lanczosWindowedSinc'
+                )
+                # Save resampled map
+                image_write(
+                    tsnr_MNI, 
+                    out_file
+                )
+
 
 if __name__ == '__main__':
     log_fmt = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'

--- a/derivatives/tsnr/resample_tsnr_maps.py
+++ b/derivatives/tsnr/resample_tsnr_maps.py
@@ -24,12 +24,18 @@ def resample_to_T1w(ds_name, tsnr_path, fmriprep_path):
     logger.info(f"loading fMRIPrep data: {fmriprep_path}")
     layout_fmriprep = bids.BIDSLayout(fmriprep_path, validate=False, is_derivative=True)
     
-    tsnr_maps = [f for f in layout_tsnr.get(suffix='statmap') if 'stat-tsnr' in f.filename and 'space-T1w' not in f.filename]
+    tsnr_maps = [f for f in layout_tsnr.get(suffix='statmap', extension='.nii.gz') if 'stat-tsnr' in f.filename]
 
     for tsnr_map in tsnr_maps:
         entities = tsnr_map.get_entities()
-        out_file = tsnr_map.path.replace(f'run-{entities["run"]}', f'run-{entities["run"]}_space-T1w')
-        
+        entities.update({
+            'space': 'T1w',
+            'stat': 'tsnr',
+        })
+
+        pattern = pattern="sub-{subject}/ses-{session}/{datatype}/sub-{subject}_ses-{session}_task-{task}_run-{run}_space-{space}[_echo-{echo}]_stat-{stat}_desc-{desc}_{suffix}.nii.gz"
+        out_file = layout_tsnr.build_path(entities, pattern, validate=False)
+
         Path(out_file).parent.mkdir(parents=True, exist_ok=True)
         if not Path(out_file).exists():
             # Get reference images from fMRIPrep directory
@@ -43,9 +49,9 @@ def resample_to_T1w(ds_name, tsnr_path, fmriprep_path):
             )
             # Validate input
             if len(t1w) == 0:
-                raise IOError(f"No T1w file associated with {tsnr_map.filename}")
+                raise IOError(f"No T1w boldref file associated with {tsnr_map.filename}")
             elif len(t1w) > 1:
-                raise IOError(f"More than one T1w file associated with {tsnr_map.filename}")
+                raise IOError(f"More than one T1w boldref file associated with {tsnr_map.filename}")
             else:
                 t1w = t1w[0]
             
@@ -80,7 +86,7 @@ def resample_to_T1w(ds_name, tsnr_path, fmriprep_path):
                     out_file
                 )
             except:
-                logger.info(f"Could not resample {os.path.basename(tsnr_map.path)}")
+                logger.info(f"Could not resample {tsnr_map.filename}")
 
 if __name__ == '__main__':
     log_fmt = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'


### PR DESCRIPTION
- Modify `make_tsnr_maps.py` to add the arguments `echo` (to specify to echo for which to compute the tSNR maps) and `me` (if specified, will get the optcom and denoised images from the tedana directory that should be specified in the `ds_path` argument)
- Modify `avg_tsnr_maps.py` to add support for multi-echo data (same `echo` and `me` arguments added). Also added `--avg_mni` and `avg_t1w` flags to specify in which space the images are)
- Add `resample_tsnr_maps.py` to resample tsnr maps computed in the native space to the T1w space for averaging purposes